### PR TITLE
Fix inverter AC power detection logic and K3 button handling

### DIFF
--- a/main/config.h
+++ b/main/config.h
@@ -18,7 +18,7 @@
 #define DISABLE_BROWNOUT_DETECTION 0
 
 // Version Information
-#define DEVICE_VERSION "3.1.2"  // v3 hardware with ESP32-S3, GPS/NTP support
+#define DEVICE_VERSION "3.1.3"  // v3 hardware with ESP32-S3, GPS/NTP support, Bug fix - K3 logic
 #define DEVICE_MANUFACTURER "Corey Smart"
 #define DEVICE_NAME "ESP32-S3 Roll-Off Roof Controller (v3)"
 

--- a/main/roof_controller.cpp
+++ b/main/roof_controller.cpp
@@ -98,7 +98,7 @@ void initializeRoofController() {
 
   // Configure AC power detection input - NEW in v3
   pinMode(INVERTER_AC_POWER_PIN, INPUT);
-  inverterACPowerState = digitalRead(INVERTER_AC_POWER_PIN);
+  inverterACPowerState = (digitalRead(INVERTER_AC_POWER_PIN) == LOW);
   lastInverterACPowerState = inverterACPowerState;
   lastInverterACPowerChangeTime = millis() - SWITCH_STABLE_TIME - 1;
 
@@ -404,7 +404,7 @@ bool startOpeningRoof() {
 
   // Determine if we need the soft-power button press
   if (inverterSoftPwrEnabled) {
-    inverterACPowerState = digitalRead(INVERTER_AC_POWER_PIN);
+    inverterACPowerState = (digitalRead(INVERTER_AC_POWER_PIN) == LOW);
     roofOpNeedsInverterButton = !inverterACPowerState;
     Debug.printf("AC power detected: %s, will %spress K3\n",
                  inverterACPowerState ? "YES" : "NO",
@@ -429,8 +429,15 @@ bool startOpeningRoof() {
     }
     roofOpState = OP_INVERTER_POWER_ON;
     roofOpStepStartTime = millis();
+  } else if (inverterSoftPwrEnabled && roofOpNeedsInverterButton) {
+    // No inverter relay, but need soft-power button press (K3) before roof button
+    Debug.println("Inverter relay disabled - pressing K3 soft-power button first");
+    digitalWrite(INVERTER_BUTTON_PIN, HIGH);
+    Debug.println("Inverter button PRESSED (K3 relay energized)");
+    roofOpState = OP_INVERTER_BUTTON_PRESS;
+    roofOpStepStartTime = millis();
   } else {
-    // No inverter relay, go directly to roof button
+    // No inverter relay, no K3 needed - go directly to roof button
     Debug.println("Inverter relay disabled - pressing roof button directly");
     digitalWrite(ROOF_CONTROL_PIN, HIGH);
     Debug.println("Button PRESSED (K2 relay energized)");
@@ -481,7 +488,7 @@ bool startClosingRoof() {
 
   // Determine if we need the soft-power button press
   if (inverterSoftPwrEnabled) {
-    inverterACPowerState = digitalRead(INVERTER_AC_POWER_PIN);
+    inverterACPowerState = (digitalRead(INVERTER_AC_POWER_PIN) == LOW);
     roofOpNeedsInverterButton = !inverterACPowerState;
     Debug.printf("AC power detected: %s, will %spress K3\n",
                  inverterACPowerState ? "YES" : "NO",
@@ -506,8 +513,15 @@ bool startClosingRoof() {
     }
     roofOpState = OP_INVERTER_POWER_ON;
     roofOpStepStartTime = millis();
+  } else if (inverterSoftPwrEnabled && roofOpNeedsInverterButton) {
+    // No inverter relay, but need soft-power button press (K3) before roof button
+    Debug.println("Inverter relay disabled - pressing K3 soft-power button first");
+    digitalWrite(INVERTER_BUTTON_PIN, HIGH);
+    Debug.println("Inverter button PRESSED (K3 relay energized)");
+    roofOpState = OP_INVERTER_BUTTON_PRESS;
+    roofOpStepStartTime = millis();
   } else {
-    // No inverter relay, go directly to roof button
+    // No inverter relay, no K3 needed - go directly to roof button
     Debug.println("Inverter relay disabled - pressing roof button directly");
     digitalWrite(ROOF_CONTROL_PIN, HIGH);
     Debug.println("Button PRESSED (K2 relay energized)");

--- a/main/roof_controller.h
+++ b/main/roof_controller.h
@@ -19,7 +19,10 @@ enum RoofOperationState {
   OP_ROOF_BUTTON_PRESS,       // K2 pressed, waiting 500ms
   OP_ROOF_BUTTON_RELEASE,     // K2 released, operation complete
   OP_STOP_BUTTON_PRESS,       // K2 pressed for stop, waiting 500ms
-  OP_STOP_BUTTON_RELEASE      // K2 released for stop, then turn off K1
+  OP_STOP_BUTTON_RELEASE,     // K2 released for stop, then shutdown inverter
+  OP_SHUTDOWN_K1_WAIT,        // K1 turned off, waiting ~1s before checking AC power
+  OP_SHUTDOWN_K3_PRESS,       // AC still on after K1 off, K3 pressed to toggle soft-power off
+  OP_SHUTDOWN_K3_RELEASE      // K3 released, shutdown complete
 };
 
 // Target direction for current operation
@@ -84,5 +87,6 @@ void sendInverterButtonPress();       // Send K3 soft-power button press
 bool getInverterRelayState();         // Get state of K1 relay
 bool getInverterACPowerState();       // Get state of AC power (via optocoupler)
 void updateInverterPowerStatus();     // Update and monitor inverter AC power state
+void shutdownInverterPower();         // Non-blocking inverter shutdown: K1 off, check AC, toggle K3 if needed
 
 #endif // ROOF_CONTROLLER_H


### PR DESCRIPTION
## Summary
This PR fixes the inverter AC power detection logic and improves the roof operation state machine to properly handle the K3 soft-power button press when the inverter relay is disabled.

## Key Changes

- **Fixed AC power detection logic**: Changed `digitalRead(INVERTER_AC_POWER_PIN)` to `(digitalRead(INVERTER_AC_POWER_PIN) == LOW)` in three locations (initialization, roof opening, and roof closing). This ensures the boolean state correctly represents whether AC power is detected (LOW = power present).

- **Added missing K3 button press handling**: Introduced a new conditional branch in both `startOpeningRoof()` and `startClosingRoof()` to handle the case where the inverter relay is disabled but a soft-power button press (K3) is still needed. Previously, this scenario would skip directly to the roof button, bypassing the required K3 press.

- **Improved state machine flow**: The roof operation now correctly transitions to `OP_INVERTER_BUTTON_PRESS` state when K3 is needed but the inverter relay is unavailable, ensuring proper sequencing of button presses.

- **Clarified comments**: Updated comments to distinguish between "no inverter relay" and "no K3 needed" scenarios for better code maintainability.

## Implementation Details

The AC power detection fix ensures that the logic correctly interprets the pin reading: a LOW signal indicates AC power is present (inverter is powered), while HIGH indicates no AC power. The boolean assignment now explicitly compares the digital read value to LOW.

The K3 button handling addition ensures that even when the inverter relay is disabled, if soft-power is enabled and AC power is not detected, the system will still attempt to press the K3 button before proceeding with the roof operation.

https://claude.ai/code/session_013Ma2oFwkw5wT8aPARBDVnC