### PR TITLE
Add PPS signal support for sub-second NTP accuracy

### DIFF
--- a/main/config.h
+++ b/main/config.h
@@ -18,7 +18,7 @@
 #define DISABLE_BROWNOUT_DETECTION 0
 
 // Version Information
-#define DEVICE_VERSION "3.1.3"  // v3 hardware with ESP32-S3, GPS/NTP support, Bug fix - K3 logic
+#define DEVICE_VERSION "3.2.0"  // v3 hardware with ESP32-S3, GPS/NTP support, PPS signal for sub-second NTP accuracy
 #define DEVICE_MANUFACTURER "Corey Smart"
 #define DEVICE_NAME "ESP32-S3 Roll-Off Roof Controller (v3)"
 
@@ -172,7 +172,7 @@ const int NTP_PORT = 123;                   // Standard NTP port
 const int16_t DEFAULT_TIMEZONE_OFFSET = 0;  // Default: UTC (0 minutes)
 const bool DEFAULT_DST_ENABLED = false;     // Default: DST disabled
 // NTP server runs independently once time is synced from GPS or RTC
-// TODO: Add PPS (Pulse Per Second) sync support for sub-second GPS accuracy
+// PPS (Pulse Per Second) provides sub-second accuracy when GPS PPS pin is configured
 
 // Enum for roof status - matches ASCOM ShutterStatus values
 enum RoofStatus {

--- a/main/gps_handler.h
+++ b/main/gps_handler.h
@@ -80,6 +80,8 @@ bool isGPSEnabled();                      // Check if GPS is enabled
 bool isGPSNtpEnabled();                   // Check if NTP server is enabled
 bool hasGPSFix();                         // Check if GPS has valid fix
 bool isTimeSynced();                      // Check if time is synced (GPS or RTC)
+bool isPPSActive();                       // Check if PPS signal is active and healthy
+uint32_t getPPSCount();                   // Get total PPS pulse count
 TimeSource getTimeSource();               // Get current time source
 GPSStatus getGPSStatus();                 // Get current GPS status
 String getTimeString();                   // Get formatted UTC time string (from best source)

--- a/main/html_templates.h
+++ b/main/html_templates.h
@@ -828,11 +828,24 @@ inline String getHomePage(RoofStatus status, bool isApMode = false) {
       }
     }
 
+    // PPS status (show when GPS is enabled and PPS pin is configured)
+    if (gpsEnabled && gpsPpsPin >= 0) {
+      bool ppsOk = isPPSActive();
+      html += "<tr><th>PPS Signal</th><td>";
+      html += "<span class='status-indicator " + String(ppsOk ? "green" : "red blink") + "'></span> ";
+      html += ppsOk ? "Active" : "No Signal";
+      if (ppsOk) {
+        html += " (pulses: " + String(getPPSCount()) + ")";
+      }
+      html += "</td></tr>\n";
+    }
+
     // NTP Server status
     html += "<tr><th>NTP Server</th><td>";
     html += "<span class='status-indicator " + String(gpsNtpEnabled && timeSynced ? "green" : (gpsNtpEnabled ? "orange" : "red")) + "'></span> ";
     if (gpsNtpEnabled && timeSynced) {
-      html += "Active (port 123)";
+      bool ppsOk = isPPSActive();
+      html += ppsOk ? "Active (port 123, PPS-disciplined)" : "Active (port 123)";
     } else if (gpsNtpEnabled) {
       html += "Waiting for time sync";
     } else {

--- a/main/html_templates.h
+++ b/main/html_templates.h
@@ -834,9 +834,6 @@ inline String getHomePage(RoofStatus status, bool isApMode = false) {
       html += "<tr><th>PPS Signal</th><td>";
       html += "<span class='status-indicator " + String(ppsOk ? "green" : "red blink") + "'></span> ";
       html += ppsOk ? "Active" : "No Signal";
-      if (ppsOk) {
-        html += " (pulses: " + String(getPPSCount()) + ")";
-      }
       html += "</td></tr>\n";
     }
 

--- a/main/web_ui_handler.cpp
+++ b/main/web_ui_handler.cpp
@@ -1194,6 +1194,11 @@ void handleGPSStatus() {
   doc["gps_time"] = getGPSTimeString();
   doc["gps_date"] = getGPSDateString();
 
+  // PPS status
+  doc["pps_active"] = isPPSActive();
+  doc["pps_count"] = getPPSCount();
+  doc["pps_pin"] = gpsPpsPin;
+
   String jsonResponse;
   serializeJson(doc, jsonResponse);
 


### PR DESCRIPTION
## Summary
Implements Pulse Per Second (PPS) signal support for the GPS module to achieve sub-second accuracy in NTP responses. This upgrade enables the device to provide microsecond-level timing precision when a PPS signal is available from the GPS receiver.

## Key Changes

- **PPS Interrupt Handler**: Added interrupt-driven PPS edge detection on the configured GPIO pin with period validation (950-1050ms) to ensure signal integrity
- **PPS Timing Correlation**: Implemented logic to correlate PPS edges with NMEA sentence timestamps, determining whether the NMEA data describes the current or previous second
- **High-Resolution NTP Timestamps**: Created `getPPSNTPTimestamp()` function that calculates NTP fractional seconds (32-bit) from microseconds elapsed since the last PPS edge
- **Enhanced NTP Response**: Updated `sendNTPResponse()` to include fractional seconds in receive and transmit timestamps when PPS is active, and adjusted precision/dispersion fields based on time source quality
- **Reference ID Updates**: NTP responses now report "PPS" as the reference clock when PPS-disciplined, or "GPS"/"LOCL" otherwise
- **Status Monitoring**: Added `isPPSActive()` and `getPPSCount()` functions to expose PPS health status; integrated PPS indicators into web UI and JSON API
- **Graceful Degradation**: System falls back to second-level accuracy when PPS signal is unavailable or unhealthy (3-second timeout)
- **Version Bump**: Updated device version from 3.1.3 to 3.2.0

## Implementation Details

- PPS signal validation includes period checking and GPS fix requirement before activation
- Microsecond-to-NTP-fraction conversion uses 64-bit arithmetic to prevent overflow
- Volatile variables protect interrupt-driven data from compiler optimization
- NTP timestamp helper function `writeNTPTimestamp()` centralizes 64-bit timestamp encoding
- Precision field set to -20 (~1μs) with PPS, -6 (~15ms) without; dispersion adjusted accordingly
- PPS interrupt properly detached when GPS is disabled to prevent dangling references

https://claude.ai/code/session_01PPdYJDVdvZsxVFntbAAEkM